### PR TITLE
Exceptions handling bug in ChakaCoreRunner

### DIFF
--- a/Src/EmbeddedScripts.JS.ChakraCore/Constants.cs
+++ b/Src/EmbeddedScripts.JS.ChakraCore/Constants.cs
@@ -1,0 +1,7 @@
+﻿namespace EmbeddedScripts.JS.ChakraCore
+{
+    internal static class Constants
+    {
+        public const string HostError = "HostError";
+    }
+}

--- a/Src/EmbeddedScripts.JS.ChakraCore/JsError.cs
+++ b/Src/EmbeddedScripts.JS.ChakraCore/JsError.cs
@@ -1,0 +1,19 @@
+﻿using ChakraHost.Hosting;
+
+namespace EmbeddedScripts.JS.ChakraCore
+{
+    internal class JsError
+    {
+        private readonly JsValue _value;
+        
+        internal JsError(JsContext context, string errorName, string message)
+        {
+            _value = new JsValue(context);
+            _value.AddProperty("name", new JsValue(context, JavaScriptValue.FromString(errorName)));
+            _value.AddProperty("message", new JsValue(context, JavaScriptValue.FromString(message)));
+        }
+        
+        public static implicit operator JavaScriptValue(JsError error) => 
+            error._value;
+    }
+}

--- a/Src/EmbeddedScripts.JS.ChakraCore/JsRuntime.cs
+++ b/Src/EmbeddedScripts.JS.ChakraCore/JsRuntime.cs
@@ -7,19 +7,13 @@ namespace EmbeddedScripts.JS.ChakraCore
     {
         private JavaScriptRuntime _runtime;
 
-        public JsRuntime()
-        {
+        public JsRuntime() =>
             _runtime = JavaScriptRuntime.Create();
-        }
 
-        public JsContext CreateContext()
-        {
-            return new(_runtime.CreateContext());
-        }
+        public JsContext CreateContext() =>
+            new(_runtime.CreateContext());
         
-        public void Dispose()
-        {
+        public void Dispose() =>
             _runtime.Dispose();
-        }
     }
 }

--- a/Src/EmbeddedScripts.JS.ChakraCore/JsValue.cs
+++ b/Src/EmbeddedScripts.JS.ChakraCore/JsValue.cs
@@ -4,9 +4,16 @@ namespace EmbeddedScripts.JS.ChakraCore
 {
     public class JsValue
     {
-        private JavaScriptValue _innerValue;
-        private JsContext _context;
+        protected JavaScriptValue _innerValue;
+        protected JsContext _context;
 
+        internal JsValue(JsContext context)
+        {
+            _context = context;
+            using (_context.Scope)
+                _innerValue = JavaScriptValue.CreateObject();
+        }
+        
         internal JsValue(JsContext context, JavaScriptValue value)
         {
             _context = context;

--- a/Tests/EmbeddedScripts.JS.ChakraCore.Tests/ChakraCoreRunnerTests.cs
+++ b/Tests/EmbeddedScripts.JS.ChakraCore.Tests/ChakraCoreRunnerTests.cs
@@ -50,7 +50,6 @@ namespace EmbeddedScripts.JS.ChakraCore.Tests
         [Fact]
         public async Task RunAsyncWithContinuation_EachRunSharesGlobals_Success()
         {
-            var code = "let x = 0;";
             using var runner = new ChakraCoreRunner();
             await _tests.RunAsyncWithContinuation_EachRunSharesGlobals_Success(runner);
         }
@@ -123,6 +122,27 @@ namespace EmbeddedScripts.JS.ChakraCore.Tests
         {
             using var runner = new ChakraCoreRunner();
             await _tests.EvaluateAsyncString(runner);
+        }
+        
+        [Fact]
+        public async Task RunCodeWithExceptionHandling_Success()
+        {
+            using var runner = new ChakraCoreRunner();
+            await _tests.RunCodeWithExceptionHandling_Success(runner);
+        }
+
+        [Fact]
+        public async Task HandleExceptionFromExposedFunction()
+        {
+            using var runner = new ChakraCoreRunner();
+            await _tests.HandleExceptionFromExposedFunction(runner);
+        }
+        
+        [Fact]
+        public async Task HandleExceptionFromExposedFunc_ErrorMessageIsEqualToExceptionMessage()
+        {
+            using var runner = new ChakraCoreRunner();
+            await _tests.HandleExceptionFromExposedFunc_ErrorMessageIsEqualToExceptionMessage(runner);
         }
 
         [Theory]

--- a/Tests/EmbeddedScripts.JS.ClearScriptV8.Tests/ClearScriptV8RunnerTests.cs
+++ b/Tests/EmbeddedScripts.JS.ClearScriptV8.Tests/ClearScriptV8RunnerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using System.Threading.Tasks;
 using EmbeddedScripts.JS.Common.Tests;
 using EmbeddedScripts.Shared.Exceptions;
@@ -115,6 +116,27 @@ namespace EmbeddedScripts.JS.ClearScriptV8.Tests
         {
             using var runner = new ClearScriptV8Runner();
             await _tests.EvaluateAsyncString(runner);
+        }
+
+        [Fact]
+        public async Task RunCodeWithExceptionHandling_Success()
+        {
+            using var runner = new ClearScriptV8Runner();
+            await _tests.RunCodeWithExceptionHandling_Success(runner);
+        }
+
+        [Fact]
+        public async Task HandleExceptionFromExposedFunction()
+        {
+            using var runner = new ClearScriptV8Runner();
+            await _tests.HandleExceptionFromExposedFunction(runner);
+        }
+        
+        [Fact]
+        public async Task HandleExceptionFromExposedFunc_ErrorMessageIsEqualToExceptionMessage()
+        {
+            using var runner = new ClearScriptV8Runner();
+            await _tests.HandleExceptionFromExposedFunc_ErrorMessageIsEqualToExceptionMessage(runner);
         }
 
         [Fact]

--- a/Tests/EmbeddedScripts.JS.Common.Tests/EmbeddedScripts.JS.Common.Tests.csproj
+++ b/Tests/EmbeddedScripts.JS.Common.Tests/EmbeddedScripts.JS.Common.Tests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
-
+        <LangVersion>latest</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/Tests/EmbeddedScripts.JS.Jint.Tests/JintCodeRunnerTests.cs
+++ b/Tests/EmbeddedScripts.JS.Jint.Tests/JintCodeRunnerTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Threading.Tasks;
 using EmbeddedScripts.JS.Common.Tests;
 using EmbeddedScripts.Shared.Exceptions;
@@ -71,8 +72,22 @@ namespace EmbeddedScripts.JS.Jint.Tests
             await _tests.NetAndJsIntegersEquality(new JintCodeRunner());
 
         [Fact]
+        public async Task RunCodeWithExceptionHandling_Success() =>
+            await _tests.RunCodeWithExceptionHandling_Success(new JintCodeRunner());
+
+        [Fact]
         public async Task EvaluateAsyncString() => 
             await _tests.EvaluateAsyncString(new JintCodeRunner());
+
+        [Fact]
+        public async Task HandleExceptionFromExposedFunction() =>
+            await _tests.HandleExceptionFromExposedFunction(
+                new JintCodeRunner().AddEngineOptions(options => options.CatchClrExceptions()));
+
+        [Fact]
+        public async Task HandleExceptionFromExposedFunc_ErrorMessageIsEqualToExceptionMessage() =>
+            await _tests.HandleExceptionFromExposedFunc_ErrorMessageIsEqualToExceptionMessage(
+                new JintCodeRunner().AddEngineOptions(options => options.CatchClrExceptions()));
         
         [Fact]
         public async void MutateRegisteredVariable_Succeed()


### PR DESCRIPTION
Bug repro: 
Code
```
runner
  .Register<Action>(() => 
    throw new ArgumentException(message), "f");
await runner.RunAsync(@"
try {
  f();
}
catch(err) {
  throw Error('aa');
}
");
```
will throw an `ArgumentException(message)` instead of `ScriptRuntimeErrorException("Error: aa")`